### PR TITLE
updated code for getting sunrise and sunset

### DIFF
--- a/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
+++ b/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
@@ -974,8 +974,14 @@ def initialize() {
     getZipCode()		// and atomicState.zipCode (because atomicState.forcePoll is true)
     
     // get sunrise/sunset for the location of the thermostats (prefers thermostat.location.postalCode)
-    def sunriseAndSunset = (atomicState.zipCode != null) ? getSunriseAndSunset(zipCode: atomicState.zipCode) : getSunRiseAndSunset()
+    def sunriseAndSunset = getSunriseAndSunset(zipCode: atomicState.zipCode)
+    if (!(sunriseAndSunset.sunrise instanceof Date)) {
+    	// the zip code is invalid or didn't return the data as expected
+	LOG("sunriseAndSunset not set as expected, using default hub location")
+	sunriseAndSunset = getSunriseAndSunset()
+    }
     LOG("sunriseAndSunset == ${sunriseAndSunset}")
+
     if(atomicState.timeZone) {
         atomicState.sunriseTime = sunriseAndSunset.sunrise.format("HHmm", TimeZone.getTimeZone(atomicState.timeZone)).toInteger()
         atomicState.sunsetTime = sunriseAndSunset.sunset.format("HHmm", TimeZone.getTimeZone(atomicState.timeZone)).toInteger()


### PR DESCRIPTION
Updated the code for getting sunrise and sunset to handle "invalid" zip codes (ex: 84009, which is a valid zip code, created 2 years ago). In some instances, it seems that the getSunriseAndSunset() method will return a map of null value "[:]" when given a particular zip code. This leads to a nullPointerException when it tries to format the null date returned.

Changed to just call with the zip code, without checking for null zip code, because the method handles null values, and returns the default (hub location) times. Added a check to make sure the returned value.sunrise contains a valid date object. If not, make the request again with no parameters, which will return the data using the hub location.